### PR TITLE
fix: return 500 on database error instead of 404

### DIFF
--- a/REPORT.md
+++ b/REPORT.md
@@ -48,3 +48,8 @@ Paste your checkpoint evidence below. Add screenshots as image files in the repo
      2. Code fix (diff or description)
      3. Post-fix response to "What went wrong?" showing the real underlying failure
      4. Healthy follow-up report or transcript after recovery -->
+
+**Proactive health report (while PostgreSQL stopped):**
+
+cat /tmp/task4b.txt >> REPORT.md
+The cron job proactively posts health summaries to the same chat session every 2 minutes.

--- a/backend/app/routers/items.py
+++ b/backend/app/routers/items.py
@@ -17,9 +17,10 @@ async def get_items(session: AsyncSession = Depends(get_session)):
     try:
         return await read_items(session)
     except Exception as exc:
+        # Fixed: Database errors should return 500, not 404
         raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail="Items not found",
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Database error: {str(exc)}",
         ) from exc
 
 


### PR DESCRIPTION
- Changed HTTP_404_NOT_FOUND to HTTP_500_INTERNAL_SERVER_ERROR in get_items()
- Database connection failures are server errors, not 'not found'
- Updated REPORT.md with fix documentation
- Closes #4

<!-- Provide a general summary of your changes in the Title above -->

## Summary

<!-- What does this PR do?

Replace <issue-number> with the number of the corresponding task issue.

Add more details if necessary.
-->

- Closes #4

---

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I made this PR to the `main` branch **of my fork (NOT the course instructors' repo)**.
- [ ] I see `base: main` <- `compare: <branch>` above the PR title.
- [ ] I edited the line `- Closes #<issue-number>`.
- [ ] I wrote clear commit messages.
- [ ] I reviewed my own diff before requesting review.
- [ ] I understand the changes I’m submitting.
